### PR TITLE
add an 'unknown' case to enums of strings

### DIFF
--- a/Sources/CreateAPI/Generator/Generator+Render.swift
+++ b/Sources/CreateAPI/Generator/Generator+Render.swift
@@ -15,10 +15,16 @@ extension Generator {
 
     private func render(_ decl: EnumOfStringsDeclaration) -> String {
         let comments = templates.comments(for: decl.metadata, name: decl.name.rawValue)
-        let cases = decl.cases.map {
+        var cases = decl.cases.map {
             templates.case(name: $0.name, value: $0.key)
-        }.joined(separator: "\n")
-        return comments + templates.enumOfStrings(name: decl.name, contents: cases)
+        }
+        var additionalStatements: [String] = []
+        if cases.count > 1 {
+            cases += [templates.case(name: "unknown", value: "unknown")]
+            additionalStatements.append(templates.initFromDecoderEnumOfStrings())
+        }
+        let contents = (cases + ["\n"] + additionalStatements).joined(separator: "\n")
+        return comments + templates.enumOfStrings(name: decl.name, contents: contents)
     }
 
     private func render(_ decl: EntityDeclaration) throws -> String {

--- a/Sources/CreateAPI/Generator/Templates.swift
+++ b/Sources/CreateAPI/Generator/Templates.swift
@@ -290,6 +290,16 @@ final class Templates {
         """
     }
 
+    func initFromDecoderEnumOfStrings() -> String {
+        return """
+        \(access)init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let rawValue = try container.decode(String.self)
+            self = Self(rawValue: rawValue) ?? .unknown
+        }
+        """
+    }
+
     func initFromDecoderOneOf(properties: [Property]) -> String {
         var statements = ""
         for property in properties {


### PR DESCRIPTION
Use this unknown case instead of throwing an exception during decoding.